### PR TITLE
chore: update CDK Android to 0.18.0-rc.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,7 +135,7 @@ dependencies {
     implementation("com.google.zxing:core:3.5.3")
 
     // CDK Kotlin bindings
-    implementation("org.cashudevkit:cdk-android:0.17.2-rc.1")
+    implementation("org.cashudevkit:cdk-android:0.18.0-rc.0")
     
     // ML Kit Barcode Scanning
     implementation("com.google.mlkit:barcode-scanning:17.3.0")

--- a/app/src/main/java/com/electricdreams/numo/core/wallet/impl/CdkWalletProvider.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/wallet/impl/CdkWalletProvider.kt
@@ -425,11 +425,11 @@ internal class CdkTemporaryMintWallet(
 
     override suspend fun refreshKeysets(): WalletResult<List<KeysetInfo>> {
         return try {
-            val keysets = cdkWallet.refreshKeysets()
+            val keysets = cdkWallet.keysets(org.cashudevkit.KeysetLoadPolicy.REFRESH)
             val result = keysets.map { keyset ->
                 KeysetInfo(
                     id = keyset.id.toString(),
-                    active = keyset.active,
+                    active = keyset.active ?: false,
                     unit = keyset.unit.toString().lowercase()
                 )
             }

--- a/app/src/main/java/com/electricdreams/numo/ndef/CashuPaymentHelper.kt
+++ b/app/src/main/java/com/electricdreams/numo/ndef/CashuPaymentHelper.kt
@@ -661,8 +661,14 @@ object CashuPaymentHelper {
                 
                 // Fetch keysets so CDK can map short Keyset IDs to full IDs
                 val keysets = try {
-                    @Suppress("UNCHECKED_CAST")
-                    tempWallet.loadMintKeysets() as List<org.cashudevkit.KeySetInfo>
+                    tempWallet.keysets(org.cashudevkit.KeysetLoadPolicy.REFRESH).map { keyset ->
+                        org.cashudevkit.KeySetInfo(
+                            id = keyset.id,
+                            unit = keyset.unit,
+                            active = keyset.active ?: false,
+                            inputFeePpk = keyset.inputFeePpk
+                        )
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load keysets for unknown mint", e)
                     throw RedemptionException("Failed to fetch keysets for unknown mint: ${e.message}", e)

--- a/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
+++ b/app/src/main/java/com/electricdreams/numo/payment/SwapToLightningMintManager.kt
@@ -109,7 +109,7 @@ object SwapToLightningMintManager {
             Log.e(TAG, msg, t)
             return@withContext SwapResult.Failure(msg)
         }
-        val keysetsInfos = tempWallet.refreshKeysets()
+        tempWallet.keysets(org.cashudevkit.KeysetLoadPolicy.REFRESH)
 
         Log.d(TAG, "swapFromUnknownMint: temporary wallet created for mint=$unknownMintUrl")
 


### PR DESCRIPTION
## Summary

- update `org.cashudevkit:cdk-android` from `0.17.2-rc.1` to `0.18.0-rc.0`
- migrate removed keyset refresh APIs to `keysets(KeysetLoadPolicy.REFRESH)`
- convert refreshed keysets to `KeySetInfo` for unknown-mint token proof decoding

## Verification

- `./gradlew testDebugUnitTest`
- `./gradlew assembleDebug`
- `./gradlew :app:dependencyInsight --dependency cdk-android --configuration debugRuntimeClasspath`