### PR TITLE
Fix developer error log collection and shorten stack traces

### DIFF
--- a/app/src/androidTest/java/com/electricdreams/numo/core/dev/ErrorLogCollectionTest.kt
+++ b/app/src/androidTest/java/com/electricdreams/numo/core/dev/ErrorLogCollectionTest.kt
@@ -1,0 +1,64 @@
+package com.electricdreams.numo.core.dev
+
+import android.content.Context
+import android.util.Log
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.electricdreams.numo.R
+import com.electricdreams.numo.feature.settings.DeveloperPrefs
+import com.electricdreams.numo.feature.settings.ErrorLogsActivity
+import com.electricdreams.numo.feature.settings.ErrorLogsAdapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ErrorLogCollectionTest {
+    @Test
+    fun realLogcatKeepsOneShortExceptionAndRefreshesTheScreen() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val previouslyEnabled = DeveloperPrefs.isDeveloperModeEnabled(context)
+        val tag = "ErrorLogTest-${System.nanoTime()}"
+        try {
+            DeveloperPrefs.setDeveloperModeEnabled(context, true)
+            ActivityScenario.launch(ErrorLogsActivity::class.java).use { scenario ->
+                val error = IllegalStateException("Synthetic collection test").apply {
+                    stackTrace = (1..150).map {
+                        StackTraceElement("com.example.Mint", "step$it", "Mint.kt", it)
+                    }.toTypedArray()
+                }
+                val before = System.currentTimeMillis()
+                Log.e(tag, "Synthetic request failed", error)
+                val deadline = System.nanoTime() + 10_000_000_000L
+                var visible = false
+                do {
+                    scenario.onActivity { activity ->
+                        val adapter = activity.findViewById<RecyclerView>(
+                            R.id.error_logs_recycler_view).adapter as ErrorLogsAdapter
+                        visible = adapter.currentList.any {
+                            it.tag == tag && it.stackTrace.orEmpty().contains("stack trace truncated")
+                        }
+                    }
+                    if (visible) break
+                    Thread.sleep(50)
+                } while (System.nanoTime() < deadline)
+                assertTrue("Log.e must reach the in-app screen through the real collector", visible)
+                // Allow all chunks of this large exception to arrive before checking row count.
+                Thread.sleep(500)
+                val entries = ErrorLogStore.getAllErrors().filter { it.tag == tag }
+                assertEquals(1, entries.size)
+                val entry = entries.single()
+                assertEquals("Synthetic request failed", entry.message)
+                assertTrue(entry.timestamp.time in before..System.currentTimeMillis())
+                assertTrue(entry.stackTrace.orEmpty().contains("Mint.step5(Mint.kt:5)"))
+                assertFalse(entry.stackTrace.orEmpty().contains("Mint.step6("))
+            }
+        } finally {
+            DeveloperPrefs.setDeveloperModeEnabled(context, previouslyEnabled)
+        }
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/NumoApplication.kt
+++ b/app/src/main/java/com/electricdreams/numo/NumoApplication.kt
@@ -3,6 +3,7 @@ package com.electricdreams.numo
 import android.app.Application
 import android.util.Log
 import com.electricdreams.numo.core.dev.ErrorLogCollector
+import com.electricdreams.numo.feature.settings.DeveloperPrefs
 
 /**
  * Custom Application class for global initialisation.
@@ -17,10 +18,8 @@ class NumoApplication : Application() {
         // Wallet initialisation is handled by onboarding / ModernPOS flows.
         Log.d("NumoApplication", "Application initialised")
 
-        // Start developer error log collection in debug builds so the
-        // Developer Settings > Error Logs screen can show recent errors
-        // without modifying existing Log.e() sites.
-        if (BuildConfig.DEBUG) {
+        // Developer Mode enables diagnostics in installed release builds too.
+        if (DeveloperPrefs.isDeveloperModeEnabled(this)) {
             ErrorLogCollector.start()
         }
     }

--- a/app/src/main/java/com/electricdreams/numo/core/data/model/ErrorLogEntry.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/data/model/ErrorLogEntry.kt
@@ -6,7 +6,7 @@ package com.electricdreams.numo.core.data.model
 import java.util.Date
 
 /**
- * Represents a single error log line, including optional stack trace.
+ * Represents an error event, including an optional abbreviated stack trace.
  */
 data class ErrorLogEntry(
     /** Unique identifier for this log entry (for stable list handling). */
@@ -17,6 +17,6 @@ data class ErrorLogEntry(
     val tag: String,
     /** Human-readable error message. */
     val message: String,
-    /** Optional stack trace string, if a throwable was provided. */
+    /** Exception description and the top stack frames, when available. */
     val stackTrace: String? = null,
 )

--- a/app/src/main/java/com/electricdreams/numo/core/dev/DevLogger.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/dev/DevLogger.kt
@@ -1,9 +1,8 @@
 /**
  * Developer logging helper.
  *
- * This wrapper mirrors [android.util.Log] for error-level logging while
- * additionally persisting error information to [ErrorLogStore] so it can
- * be inspected from the in-app Developer Settings.
+ * Errors are persisted by [ErrorLogCollector] when Developer Mode is enabled.
+ * Use the same collection path as Log.e to avoid recording each error twice.
  */
 package com.electricdreams.numo.core.dev
 
@@ -12,7 +11,7 @@ import android.util.Log
 object DevLogger {
 
     /**
-     * Log an error message and persist it to [ErrorLogStore].
+     * Log an error message for logcat and the developer error collector.
      */
     @JvmStatic
     fun e(tag: String, message: String, throwable: Throwable? = null) {
@@ -21,8 +20,6 @@ object DevLogger {
         } else {
             Log.e(tag, message)
         }
-
-        ErrorLogStore.appendError(tag = tag, message = message, throwable = throwable)
     }
 
     /**
@@ -30,6 +27,6 @@ object DevLogger {
      */
     @JvmStatic
     fun e(tag: String, message: String) {
-        e(tag, message, null as Throwable?)
+        e(tag, message, null)
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/core/dev/ErrorLogCollector.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/dev/ErrorLogCollector.kt
@@ -1,111 +1,116 @@
-/**
- * Background collector that mirrors android.util.Log error output for this
- * process into [ErrorLogStore] by tailing logcat.
- *
- * This keeps the existing Log.e() usage intact while providing an in-app
- * history of recent errors for the Developer Settings > Error Logs screen.
- */
 package com.electricdreams.numo.core.dev
 
-import android.os.Build
 import android.os.Process
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.concurrent.atomic.AtomicBoolean
+import android.util.Log
+import com.electricdreams.numo.core.data.model.ErrorLogEntry
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
+/** Collects this process's errors while Developer Mode is enabled, in every build variant. */
 object ErrorLogCollector {
-
-    private val running = AtomicBoolean(false)
-    private var workerThread: Thread? = null
-
-    // Example logcat -v time prefix: "03-15 12:34:56.789"
-    private val logcatDateFormat = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US)
-
-    /**
-     * Start tailing logcat for this process's error-level logs.
-     * Safe to call multiple times; only the first call starts the collector.
-     */
-    fun start() {
-        if (!running.compareAndSet(false, true)) return
-
-        workerThread = Thread {
-            try {
-                val pid = Process.myPid()
-                val cmd = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    arrayOf("logcat", "-v", "time", "--pid", pid.toString(), "*:E")
-                } else {
-                    arrayOf("logcat", "-v", "time", "*:E")
-                }
-
-                val process = Runtime.getRuntime().exec(cmd)
-                BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
-                    var line: String?
-                    while (running.get()) {
-                        line = reader.readLine() ?: break
-                        parseAndStoreLine(line!!, pid)
-                    }
-                }
-                process.destroy()
-            } catch (_: Throwable) {
-                // Collector is best-effort for developer diagnostics; ignore failures.
-            } finally {
-                running.set(false)
-            }
-        }.apply {
-            name = "Numo-ErrorLogCollector"
-            isDaemon = true
-            start()
-        }
-    }
-
-    /**
-     * Stop tailing logcat.
-     */
-    fun stop() {
-        running.set(false)
-        workerThread?.interrupt()
-        workerThread = null
-    }
-
-    private fun parseAndStoreLine(raw: String, pid: Int) {
-        // For pre-N devices, filter out other pids manually.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N && !raw.contains(" $pid ")) {
-            return
-        }
-
-        // Expected -v time format: "MM-dd HH:mm:ss.SSS PID T TAG: message"
-        val firstSpace = raw.indexOf(' ')
-        val secondSpace = if (firstSpace > 0) raw.indexOf(' ', firstSpace + 1) else -1
-        if (secondSpace <= 0) return
-
-        val timestampStr = raw.substring(0, secondSpace) // "MM-dd HH:mm:ss.SSS"
-        val rest = raw.substring(secondSpace + 1)
-
-        val colonIndex = rest.indexOf(':')
-        if (colonIndex <= 0) return
-
-        val header = rest.substring(0, colonIndex).trim()
-        val message = rest.substring(colonIndex + 1).trim()
-
-        // header typically ends with the tag, e.g. "1234 1234 E MyTag"
-        val parts = header.split(Regex("\\s+"))
-        val tag = parts.lastOrNull() ?: "Unknown"
-
-        val timestamp = parseTimestamp(timestampStr) ?: Date()
-
-        ErrorLogStore.appendError(
-            tag = tag,
-            message = message,
-            throwable = null,
+    private val monitor by lazy {
+        ErrorLogMonitor(
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+            pid = Process.myPid(),
+            processFactory = { pid ->
+                ProcessBuilder("logcat", "-B", "--pid", pid.toString(),
+                    "-b", "main", "-b", "system", "-b", "crash")
+                    .redirectErrorStream(true)
+                    .start()
+            },
+            record = ErrorLogStore::record,
         )
     }
 
-    private fun parseTimestamp(value: String): Date? = try {
-        logcatDateFormat.parse(value)
-    } catch (_: Exception) {
-        null
+    val state get() = monitor.state
+
+    fun start() = monitor.start()
+
+    fun stop() = monitor.stop()
+}
+
+enum class ErrorLogCollectionState { STOPPED, STARTING, COLLECTING, RETRYING }
+
+/** Owns the subprocess so stopping collection also unblocks a pending read. */
+internal class ErrorLogMonitor(
+    private val scope: CoroutineScope,
+    private val pid: Int,
+    private val processFactory: (Int) -> java.lang.Process,
+    private val record: (ErrorLogEntry) -> Unit,
+) {
+    private val mutableState = MutableStateFlow(ErrorLogCollectionState.STOPPED)
+    val state = mutableState.asStateFlow()
+    private var job: Job? = null
+    private var process: java.lang.Process? = null
+
+    @Synchronized
+    fun start() {
+        if (job?.isActive == true) return
+        mutableState.value = ErrorLogCollectionState.STARTING
+        job = scope.launch {
+            var retryDelay = 1_000L
+            while (isActive) {
+                var child: java.lang.Process? = null
+                try {
+                    synchronized(this@ErrorLogMonitor) {
+                        if (!isActive) return@launch
+                        child = processFactory(pid)
+                        process = child
+                        mutableState.value = ErrorLogCollectionState.COLLECTING
+                    }
+                    val activeProcess = child ?: return@launch
+                    val assembler = ErrorLogAssembler(record)
+                    activeProcess.inputStream.buffered().use { input ->
+                        val reader = LogcatRecordReader(input, pid)
+                        while (isActive) {
+                            val entry = reader.read() ?: throw IOException("logcat closed its output")
+                            ensureActive()
+                            assembler.accept(entry)
+                            retryDelay = 1_000L
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    synchronized(this@ErrorLogMonitor) {
+                        if (isActive) {
+                            mutableState.value = ErrorLogCollectionState.RETRYING
+                            // Warning level avoids feeding collection failures back into the store.
+                            Log.w(TAG, "Error log collection failed; retrying", e)
+                        }
+                    }
+                } finally {
+                    synchronized(this@ErrorLogMonitor) {
+                        child?.destroy()
+                        if (process === child) process = null
+                    }
+                }
+                delay(retryDelay)
+                retryDelay = (retryDelay * 2).coerceAtMost(30_000L)
+            }
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        job?.cancel()
+        job = null
+        process?.destroy()
+        process = null
+        mutableState.value = ErrorLogCollectionState.STOPPED
+    }
+
+    companion object {
+        private const val TAG = "ErrorLogCollector"
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/core/dev/ErrorLogStore.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/dev/ErrorLogStore.kt
@@ -1,95 +1,135 @@
-/**
- * Persistent storage for developer error logs.
- *
- * This store keeps a bounded list of [ErrorLogEntry] objects in SharedPreferences,
- * allowing the Developer Settings > Error Logs screen to display recent
- * application errors without relying on external logcat access.
- */
 package com.electricdreams.numo.core.dev
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
 import com.electricdreams.numo.AppGlobals
 import com.electricdreams.numo.core.data.model.ErrorLogEntry
 import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
+import com.google.gson.stream.JsonWriter
 import java.util.Date
 import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 
+/** Bounded persistent error history. Call reads and writes from Dispatchers.IO. */
 object ErrorLogStore {
-
+    private const val TAG = "ErrorLogStore"
     private const val PREFS_NAME = "DeveloperErrorLogs"
     private const val KEY_LOGS = "logs"
     private const val MAX_ENTRIES = 500
 
-    private val gson = Gson()
-
-    private val context: Context
-        get() = AppGlobals.getAppContext()
-
-    /**
-     * Append a new error entry to the store.
-     * Oldest entries are discarded when [MAX_ENTRIES] is exceeded.
-     */
-    @Synchronized
-    fun appendError(tag: String, message: String, throwable: Throwable? = null) {
-        val entries = loadAllInternal().toMutableList()
-
-        val stack = throwable?.stackTraceToString()
-
-        entries.add(
-            ErrorLogEntry(
-                id = UUID.randomUUID().toString(),
-                timestamp = Date(),
-                tag = tag,
-                message = message,
-                stackTrace = stack,
-            ),
-        )
-
-        val trimmedEntries = if (entries.size > MAX_ENTRIES) {
-            entries.takeLast(MAX_ENTRIES)
-        } else {
-            entries
+    private val legacyDateAdapter = Gson().getAdapter(Date::class.java)
+    private val gson = GsonBuilder().registerTypeAdapter(Date::class.java, object : TypeAdapter<Date>() {
+        override fun write(writer: JsonWriter, value: Date?) {
+            if (value == null) writer.nullValue() else writer.value(value.time)
         }
 
-        saveAll(trimmedEntries)
+        override fun read(reader: JsonReader): Date? = when (reader.peek()) {
+            JsonToken.NUMBER -> Date(reader.nextLong())
+            JsonToken.NULL -> { reader.nextNull(); null }
+            else -> legacyDateAdapter.read(reader) // Preserve logs saved by older app versions.
+        }
+    }).create()
+
+    private fun preferences(): SharedPreferences = AppGlobals.getAppContext()
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun appendError(
+        tag: String,
+        message: String,
+        throwable: Throwable? = null,
+        timestamp: Date = Date(),
+    ) {
+        record(ErrorLogEntry(
+            id = UUID.randomUUID().toString(),
+            timestamp = timestamp,
+            tag = tag,
+            message = message,
+            stackTrace = ErrorLogSummary.stackTop(throwable?.stackTraceToString()),
+        ))
     }
 
-    /**
-     * Returns all error entries whose timestamp is less than or equal to [endInclusive].
-     * Entries are sorted by timestamp ascending.
-     */
-    fun getErrorsUpTo(endInclusive: Date): List<ErrorLogEntry> {
-        return loadAllInternal()
-            .filter { it.timestamp.time <= endInclusive.time }
-            .sortedBy { it.timestamp.time }
-    }
-
-    /**
-     * Returns all stored error entries sorted by timestamp ascending.
-     */
-    fun getAllErrors(): List<ErrorLogEntry> =
-        loadAllInternal().sortedBy { it.timestamp.time }
-
-    /**
-     * Remove all stored error entries.
-     */
+    /** Update a split exception or ignore a record replayed after a collector restart. */
     @Synchronized
-    fun clearAll() {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        prefs.edit().putString(KEY_LOGS, "[]").apply()
+    internal fun record(entry: ErrorLogEntry) {
+        val entries = loadAllInternal().toMutableList()
+        val bounded = entry.copy(stackTrace = ErrorLogSummary.stackTop(entry.stackTrace))
+        val existing = entries.indexOfFirst { it.id == bounded.id }
+        if (existing >= 0) {
+            if (entries[existing] == bounded) return
+            entries[existing] = bounded
+        } else {
+            entries.add(bounded)
+        }
+        saveAll(entries.sortedBy { it.timestamp.time }.takeLast(MAX_ENTRIES))
     }
+
+    @Synchronized
+    fun getErrorsUpTo(endInclusive: Date): List<ErrorLogEntry> =
+        getAllErrors().filter { it.timestamp.time <= endInclusive.time }
+
+    @Synchronized
+    fun getAllErrors(): List<ErrorLogEntry> = loadAllInternal().sortedBy { it.timestamp.time }
+
+    /** Register before the initial read so an error arriving as the screen opens isn't missed. */
+    fun observeErrors(): Flow<List<ErrorLogEntry>> = callbackFlow {
+        val prefs = preferences()
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_LOGS || key == null) trySend(Unit)
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        trySend(Unit)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }.conflate().map { getAllErrors() }.flowOn(Dispatchers.IO)
+
+    @Synchronized
+    fun clearAll() = saveAll(emptyList())
 
     private fun loadAllInternal(): List<ErrorLogEntry> {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val json = prefs.getString(KEY_LOGS, "[]")
-        val type = object : TypeToken<ArrayList<ErrorLogEntry>>() {}.type
-        return gson.fromJson(json, type) ?: emptyList()
+        val array = try {
+            val json = preferences().getString(KEY_LOGS, "[]") ?: "[]"
+            val parsed = JsonParser.parseString(json)
+            if (!parsed.isJsonArray) throw JsonParseException("Expected an error log array")
+            parsed.asJsonArray
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "Discarding unreadable error history", e)
+            saveAll(emptyList())
+            return emptyList()
+        }
+
+        val entries = array.mapNotNull { value ->
+            try {
+                val obj = value.asJsonObject
+                for (field in listOf("id", "timestamp", "tag", "message")) {
+                    if (!obj.has(field) || obj[field].isJsonNull) {
+                        throw JsonParseException("Error log is missing $field")
+                    }
+                }
+                gson.fromJson(obj, ErrorLogEntry::class.java).let {
+                    it.copy(stackTrace = ErrorLogSummary.stackTop(it.stackTrace))
+                }
+            } catch (e: RuntimeException) {
+                Log.w(TAG, "Discarding a malformed error log entry", e)
+                null
+            }
+        }
+        if (entries.size != array.size()) saveAll(entries)
+        return entries
     }
 
     private fun saveAll(entries: List<ErrorLogEntry>) {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val json = gson.toJson(entries)
-        prefs.edit().putString(KEY_LOGS, json).apply()
+        preferences().edit().putString(KEY_LOGS, gson.toJson(entries)).apply()
     }
 }

--- a/app/src/main/java/com/electricdreams/numo/core/dev/ErrorLogSummary.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/dev/ErrorLogSummary.kt
@@ -1,0 +1,71 @@
+package com.electricdreams.numo.core.dev
+
+import com.electricdreams.numo.core.data.model.ErrorLogEntry
+
+internal object ErrorLogSummary {
+    private const val MAX_STACK_LINES = 6 // Exception description and the first five frames.
+    private const val MAX_MESSAGE_CHARS = 4_096
+    private const val TRUNCATED = "… (stack trace truncated)"
+    private val frame = Regex("^at\\s+\\S+\\(.*\\)$")
+    private val omittedFrames = Regex("^\\.\\.\\. \\d+ more$")
+
+    fun isContinuation(message: String): Boolean {
+        val first = message.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+        return frame.matches(first) || first.startsWith("Caused by:") ||
+            first.startsWith("Suppressed:") || omittedFrames.matches(first)
+    }
+
+    fun stackTop(stack: String?): String? {
+        if (stack.isNullOrBlank()) return null
+        val lines = stack.trim().lineSequence().take(MAX_STACK_LINES + 1).toList()
+        return lines.take(MAX_STACK_LINES).joinToString("\n") { it.take(MAX_MESSAGE_CHARS) } +
+            if (lines.size > MAX_STACK_LINES) "\n$TRUNCATED" else ""
+    }
+
+    fun fromRecord(record: LogcatRecord): ErrorLogEntry {
+        val lines = record.message.trimEnd().lines()
+        val firstFrame = lines.indexOfFirst { isContinuation(it) }
+        val traceStart = when {
+            firstFrame < 0 -> lines.size
+            firstFrame == 0 -> 0
+            else -> firstFrame - 1
+        }
+        val message = if (traceStart == 0) lines.first() else lines.take(traceStart).joinToString("\n")
+        return ErrorLogEntry(
+            id = record.id,
+            timestamp = record.timestamp,
+            tag = record.tag,
+            message = message.take(MAX_MESSAGE_CHARS),
+            stackTrace = stackTop(lines.drop(traceStart).joinToString("\n")),
+        )
+    }
+
+    fun appendStack(existing: String?, continuation: String): String? {
+        if (existing?.endsWith(TRUNCATED) == true) return existing
+        return stackTop(listOfNotNull(existing, continuation).joinToString("\n"))
+    }
+}
+
+/** Android may split a large throwable into multiple log records. Keep its tail out of the list. */
+internal class ErrorLogAssembler(private val record: (ErrorLogEntry) -> Unit) {
+    private data class Pending(val entry: ErrorLogEntry, val lastTimestamp: Long)
+    private val pending = LinkedHashMap<Pair<Int, String>, Pending>()
+
+    fun accept(raw: LogcatRecord) {
+        val key = raw.threadId to raw.tag
+        val previous = pending[key]
+        val entry = if (previous != null && ErrorLogSummary.isContinuation(raw.message) &&
+            raw.timestamp.time - previous.lastTimestamp in 0..1_000
+        ) {
+            previous.entry.copy(
+                stackTrace = ErrorLogSummary.appendStack(previous.entry.stackTrace, raw.message),
+            )
+        } else {
+            ErrorLogSummary.fromRecord(raw)
+        }
+        record(entry)
+        pending.remove(key)
+        pending[key] = Pending(entry, raw.timestamp.time)
+        if (pending.size > 64) pending.remove(pending.keys.first())
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/core/dev/LogcatRecordReader.kt
+++ b/app/src/main/java/com/electricdreams/numo/core/dev/LogcatRecordReader.kt
@@ -1,0 +1,66 @@
+package com.electricdreams.numo.core.dev
+
+import java.io.DataInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.Date
+import java.util.UUID
+
+internal data class LogcatRecord(
+    val id: String,
+    val timestamp: Date,
+    val threadId: Int,
+    val tag: String,
+    val message: String,
+)
+
+/**
+ * Reads logcat -B's length-prefixed logger_entry records (Android's log/log_read.h).
+ * Binary records preserve message boundaries, embedded newlines and epoch timestamps.
+ * Filter here: logcat's text priority filters are not applied to binary output.
+ */
+internal class LogcatRecordReader(input: InputStream, private val pid: Int) {
+    private val input = DataInputStream(input)
+
+    fun read(): LogcatRecord? {
+        while (true) {
+            val firstByte = input.read()
+            if (firstByte == -1) return null
+            val payloadSize = firstByte or (input.readUnsignedByte() shl 8)
+            val headerSize = input.readUnsignedByte() or (input.readUnsignedByte() shl 8)
+            if (headerSize !in 24..64 || payloadSize !in 3..65_535) {
+                throw IOException("Invalid logcat record header")
+            }
+            val headerBytes = ByteArray(headerSize - 4).also(input::readFully)
+            val payload = ByteArray(payloadSize).also(input::readFully)
+            val header = ByteBuffer.wrap(headerBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val recordPid = header.int
+            val threadId = header.int
+            val seconds = header.int.toLong() and 0xffffffffL
+            val nanos = header.int.toLong() and 0xffffffffL
+            val bufferId = header.int
+            if (recordPid != pid || bufferId !in TEXT_BUFFERS || payload[0].toInt() !in 6..7) {
+                continue
+            }
+            if (nanos >= 1_000_000_000L) throw IOException("Invalid logcat timestamp")
+            val tagEnd = (1 until payload.size).firstOrNull { payload[it] == 0.toByte() }
+                ?: throw IOException("Missing logcat tag terminator")
+            val messageEnd = if (payload.last() == 0.toByte()) payload.lastIndex else payload.size
+            if (tagEnd >= messageEnd) continue
+            return LogcatRecord(
+                // Stable across collector retries, including sub-millisecond event identity.
+                id = UUID.nameUUIDFromBytes(headerBytes + payload).toString(),
+                timestamp = Date(seconds * 1_000 + nanos / 1_000_000),
+                threadId = threadId,
+                tag = String(payload, 1, tagEnd - 1, Charsets.UTF_8),
+                message = String(payload, tagEnd + 1, messageEnd - tagEnd - 1, Charsets.UTF_8),
+            )
+        }
+    }
+
+    companion object {
+        private val TEXT_BUFFERS = setOf(0, 3, 4) // main, system, crash
+    }
+}

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperPrefs.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/DeveloperPrefs.kt
@@ -2,6 +2,7 @@ package com.electricdreams.numo.feature.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.electricdreams.numo.core.dev.ErrorLogCollector
 
 /**
  * Manages developer settings preferences.
@@ -22,6 +23,7 @@ object DeveloperPrefs {
 
     fun setDeveloperModeEnabled(context: Context, enabled: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_DEVELOPER_MODE_ENABLED, enabled).apply()
+        if (enabled) ErrorLogCollector.start() else ErrorLogCollector.stop()
     }
 
     fun isLightningInvoiceDelayed(context: Context): Boolean {

--- a/app/src/main/java/com/electricdreams/numo/feature/settings/ErrorLogsActivity.kt
+++ b/app/src/main/java/com/electricdreams/numo/feature/settings/ErrorLogsActivity.kt
@@ -11,6 +11,9 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import java.text.SimpleDateFormat
@@ -21,8 +24,11 @@ import java.util.Locale
 import com.electricdreams.numo.R
 import com.electricdreams.numo.core.data.model.ErrorLogEntry
 import com.electricdreams.numo.core.dev.ErrorLogStore
+import com.electricdreams.numo.core.dev.ErrorLogCollector
+import com.electricdreams.numo.core.dev.ErrorLogCollectionState
 import com.electricdreams.numo.databinding.ActivityErrorLogsBinding
 import com.electricdreams.numo.ui.util.applySettingsWindowInsets
+import kotlinx.coroutines.launch
 
 /**
  * Developer-facing screen that displays persisted error logs and allows
@@ -37,6 +43,8 @@ class ErrorLogsActivity : AppCompatActivity() {
     private lateinit var emptyView: TextView
 
     private val calendar: Calendar = Calendar.getInstance()
+    private var followToday = true
+    private var allLogs: List<ErrorLogEntry> = emptyList()
     private val headerDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     private val lineDateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
 
@@ -45,6 +53,10 @@ class ErrorLogsActivity : AppCompatActivity() {
         binding = ActivityErrorLogsBinding.inflate(layoutInflater)
         setContentView(binding.root)
         applySettingsWindowInsets(this, binding.root)
+        if (savedInstanceState != null) {
+            calendar.timeInMillis = savedInstanceState.getLong(KEY_FILTER_DATE, calendar.timeInMillis)
+            followToday = savedInstanceState.getBoolean(KEY_FOLLOW_TODAY, true)
+        }
 
         binding.topBar.onNavClick { finish() }
 
@@ -70,8 +82,40 @@ class ErrorLogsActivity : AppCompatActivity() {
             shareLogs()
         }
 
-        updateDateLabel()
-        loadLogsForCurrentDate()
+        showLogsForCurrentDate()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    ErrorLogStore.observeErrors().collect { logs ->
+                        allLogs = logs
+                        showLogsForCurrentDate()
+                    }
+                }
+                launch {
+                    ErrorLogCollector.state.collect { state ->
+                        binding.collectionStatus.visibility = if (
+                            state == ErrorLogCollectionState.COLLECTING
+                        ) View.GONE else View.VISIBLE
+                        binding.collectionStatus.setText(when (state) {
+                            ErrorLogCollectionState.RETRYING -> R.string.developer_error_logs_retrying
+                            ErrorLogCollectionState.STOPPED -> R.string.developer_error_logs_disabled
+                            else -> R.string.developer_error_logs_starting
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (DeveloperPrefs.isDeveloperModeEnabled(this)) ErrorLogCollector.start()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putLong(KEY_FILTER_DATE, calendar.timeInMillis)
+        outState.putBoolean(KEY_FOLLOW_TODAY, followToday)
+        super.onSaveInstanceState(outState)
     }
 
     private fun showDatePicker() {
@@ -84,8 +128,8 @@ class ErrorLogsActivity : AppCompatActivity() {
             { _, y, m, d ->
                 calendar.set(y, m, d, 23, 59, 59)
                 calendar.set(Calendar.MILLISECOND, 999)
-                updateDateLabel()
-                loadLogsForCurrentDate()
+                followToday = isSameDay(calendar.time, Date())
+                showLogsForCurrentDate()
             },
             year,
             month,
@@ -102,13 +146,22 @@ class ErrorLogsActivity : AppCompatActivity() {
         }
     }
 
-    private fun loadLogsForCurrentDate() {
-        val endOfDay: Date = calendar.time
-        val logs = ErrorLogStore.getErrorsUpTo(endOfDay)
+    private fun showLogsForCurrentDate() {
+        if (followToday) calendar.timeInMillis = System.currentTimeMillis()
+        updateDateLabel()
+        val endOfDay = (calendar.clone() as Calendar).apply {
+            set(Calendar.HOUR_OF_DAY, 23)
+            set(Calendar.MINUTE, 59)
+            set(Calendar.SECOND, 59)
+            set(Calendar.MILLISECOND, 999)
+        }.timeInMillis
+        val logs = allLogs.filter { it.timestamp.time <= endOfDay }
         adapter.submitList(logs)
 
         val isEmpty = logs.isEmpty()
         emptyView.visibility = if (isEmpty) View.VISIBLE else View.GONE
+        binding.copyAllButton.isEnabled = !isEmpty
+        binding.shareButton.isEnabled = !isEmpty
     }
 
     private fun showEntryDetails(entry: ErrorLogEntry) {
@@ -178,5 +231,10 @@ class ErrorLogsActivity : AppCompatActivity() {
         val c2 = Calendar.getInstance().apply { time = d2 }
         return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR) &&
             c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR)
+    }
+
+    companion object {
+        private const val KEY_FILTER_DATE = "error_log_filter_date"
+        private const val KEY_FOLLOW_TODAY = "error_log_follow_today"
     }
 }

--- a/app/src/main/res/layout/activity_error_logs.xml
+++ b/app/src/main/res/layout/activity_error_logs.xml
@@ -85,6 +85,19 @@
 
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/collection_status"
+            style="@style/Text.Caption"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/settings_page_margin"
+            android:layout_marginTop="@dimen/space_s"
+            android:accessibilityLiveRegion="polite"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/date_filter_row"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
         <!-- RecyclerView for log entries -->
 
         <androidx.recyclerview.widget.RecyclerView
@@ -94,7 +107,7 @@
             android:layout_marginTop="@dimen/space_s"
             android:clipToPadding="false"
             android:paddingBottom="16dp"
-            app:layout_constraintTop_toBottomOf="@id/date_filter_row"
+            app:layout_constraintTop_toBottomOf="@id/collection_status"
             app:layout_constraintBottom_toTopOf="@id/action_bar"
             android:paddingHorizontal="@dimen/settings_page_margin" />
 
@@ -107,7 +120,7 @@
             android:layout_height="wrap_content"
             android:text="@string/developer_error_logs_empty"
             android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/date_filter_row"
+            app:layout_constraintTop_toBottomOf="@id/collection_status"
             app:layout_constraintBottom_toTopOf="@id/action_bar"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values-de/strings_developer_settings.xml
+++ b/app/src/main/res/values-de/strings_developer_settings.xml
@@ -5,4 +5,7 @@
         Damit wird der Abschlussstatus des Onboardings gelöscht und du kehrst zum Willkommensbildschirm zurück. Möchtest du wirklich fortfahren?
     </string>
     <string name="developer_settings_restart_dialog_positive">Neu starten</string>
+    <string name="developer_error_logs_starting">Fehlerprotokollierung wird gestartet…</string>
+    <string name="developer_error_logs_retrying">Fehlerprotokollierung nicht verfügbar. Ein neuer Versuch erfolgt automatisch…</string>
+    <string name="developer_error_logs_disabled">Aktiviere den Entwicklermodus, um neue Fehler aufzuzeichnen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings_developer_settings.xml
+++ b/app/src/main/res/values-es/strings_developer_settings.xml
@@ -5,4 +5,7 @@
         Esto borrará el estado de finalización del onboarding y te llevará de nuevo a la pantalla de bienvenida. ¿Seguro que quieres continuar?
     </string>
     <string name="developer_settings_restart_dialog_positive">Reiniciar</string>
+    <string name="developer_error_logs_starting">Iniciando el registro de errores…</string>
+    <string name="developer_error_logs_retrying">El registro de errores no está disponible. Se reintentará automáticamente…</string>
+    <string name="developer_error_logs_disabled">Activa el modo de desarrollador para registrar nuevos errores.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings_developer_settings.xml
+++ b/app/src/main/res/values-ja/strings_developer_settings.xml
@@ -5,4 +5,7 @@
  </string>
     <string name="developer_settings_restart_dialog_title">オンボーディングの再起動</string>
     <string name="developer_settings_restart_dialog_positive">再起動</string>
+    <string name="developer_error_logs_starting">エラーログの記録を開始しています…</string>
+    <string name="developer_error_logs_retrying">エラーログを記録できません。自動的に再試行します…</string>
+    <string name="developer_error_logs_disabled">新しいエラーを記録するには、開発者モードを有効にしてください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings_developer_settings.xml
+++ b/app/src/main/res/values-ko/strings_developer_settings.xml
@@ -5,4 +5,7 @@
  </string>
     <string name="developer_settings_restart_dialog_title">온보딩 다시 시작</string>
     <string name="developer_settings_restart_dialog_positive">다시 시작</string>
+    <string name="developer_error_logs_starting">오류 로그 기록을 시작하는 중…</string>
+    <string name="developer_error_logs_retrying">오류 로그를 기록할 수 없습니다. 자동으로 다시 시도합니다…</string>
+    <string name="developer_error_logs_disabled">새 오류를 기록하려면 개발자 모드를 사용 설정하세요.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings_developer_settings.xml
+++ b/app/src/main/res/values-pt/strings_developer_settings.xml
@@ -5,4 +5,7 @@
         Isso limpará o status de conclusão do onboarding e levará você de volta à tela de boas-vindas. Tem certeza de que deseja continuar?
     </string>
     <string name="developer_settings_restart_dialog_positive">Reiniciar</string>
+    <string name="developer_error_logs_starting">Iniciando o registro de erros…</string>
+    <string name="developer_error_logs_retrying">O registro de erros está indisponível. Uma nova tentativa será feita automaticamente…</string>
+    <string name="developer_error_logs_disabled">Ative o modo de desenvolvedor para registrar novos erros.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,6 +320,9 @@
     <string name="developer_error_logs_copy_all">Copy All</string>
     <string name="developer_error_logs_share">Share</string>
     <string name="developer_error_logs_empty">No error logs available.</string>
+    <string name="developer_error_logs_starting">Starting error collection…</string>
+    <string name="developer_error_logs_retrying">Error collection is unavailable. Retrying automatically…</string>
+    <string name="developer_error_logs_disabled">Enable Developer Mode to collect new errors.</string>
     <string name="developer_error_logs_copied">Error logs copied to clipboard</string>
     <string name="developer_error_logs_share_title">Share Error Logs</string>
 

--- a/app/src/test/java/com/electricdreams/numo/core/dev/ErrorLogCollectorParseTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/dev/ErrorLogCollectorParseTest.kt
@@ -1,85 +1,110 @@
 package com.electricdreams.numo.core.dev
 
 import com.electricdreams.numo.core.data.model.ErrorLogEntry
+import java.io.ByteArrayInputStream
+import java.io.IOException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
-/**
- * Unit tests for [ErrorLogCollector] parsing logic.
- *
- * These tests focus on verifying that sample logcat lines are parsed into
- * correct tag/message values and forwarded to [ErrorLogStore]. To avoid
- * touching the real store, this test uses a simple FakeErrorLogStore.
- */
 class ErrorLogCollectorParseTest {
+    @Test
+    fun `real binary record preserves tag unicode multiline message and timestamp`() {
+        val message = "❌ Failed: timeout\n\nRequest details: mint unavailable"
+        val reader = reader(logcatBytes(message, tag = "Mint: withdrawal worker"))
+        val record = requireNotNull(reader.read())
+        assertEquals("Mint: withdrawal worker", record.tag)
+        assertEquals(message, record.message)
+        assertEquals(1_767_225_600_123L, record.timestamp.time)
+        assertEquals(1235, record.threadId)
+        assertNull(reader.read())
+    }
 
     @Test
-    fun `parseAndStoreLine extracts tag and message from -v time format`() {
-        val fakeStore = FakeErrorLogStore()
-        val collector = TestableErrorLogCollector(fakeStore)
-
-        val sampleLine = "03-15 12:34:56.789  1234  1234 E AutoWithdrawManager: ❌ Auto-withdrawal failed: some error"
-
-        collector.invokeParse(sampleLine, pid = 1234)
-
-        assertEquals(1, fakeStore.entries.size)
-        val entry = fakeStore.entries.first()
-        assertEquals("AutoWithdrawManager", entry.tag)
-        assertEquals("❌ Auto-withdrawal failed: some error", entry.message)
-    }
-
-    private class FakeErrorLogStore {
-        val entries = mutableListOf<ErrorLogEntry>()
-
-        fun append(tag: String, message: String) {
-            entries.add(
-                ErrorLogEntry(
-                    id = "test",
-                    timestamp = Date(),
-                    tag = tag,
-                    message = message,
-                    stackTrace = null,
-                ),
-            )
+    fun `reader accepts both 24 and 28 byte Android headers`() {
+        for (size in listOf(24, 28)) {
+            assertEquals("Failure", reader(logcatBytes("Failure", headerSize = size)).read()?.message)
         }
     }
 
-    private class TestableErrorLogCollector(
-        private val fakeStore: FakeErrorLogStore,
-    ) {
-        private val logcatDateFormat = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US)
+    @Test
+    fun `only errors and fatal records from this process and text buffers are collected`() {
+        val stream = logcatBytes("Other app", pid = 9000) + logcatBytes("Warning", priority = 5) +
+            logcatBytes("Event buffer", buffer = 2) + logcatBytes("Error") +
+            logcatBytes("Fatal", priority = 7, buffer = 4)
+        val reader = reader(stream)
+        assertEquals("Error", reader.read()?.message)
+        assertEquals("Fatal", reader.read()?.message)
+        assertNull(reader.read())
+    }
 
-        fun invokeParse(raw: String, pid: Int) {
-            // Direct copy of ErrorLogCollector.parseAndStoreLine, but writing to fake store.
-            if (!raw.contains(" $pid ")) return
+    @Test
+    fun `truncated records and unexpected subprocess text report a read failure`() {
+        assertThrows(IOException::class.java) { reader(logcatBytes("Error").dropLast(2).toByteArray()).read() }
+        assertThrows(IOException::class.java) { reader("logcat: Permission denied".toByteArray()).read() }
+    }
 
-            val firstSpace = raw.indexOf(' ')
-            val secondSpace = if (firstSpace > 0) raw.indexOf(' ', firstSpace + 1) else -1
-            if (secondSpace <= 0) return
+    @Test
+    fun `replayed records retain identity and distinct nanosecond timestamps remain distinct`() {
+        val first = reader(logcatBytes("Failure")).read()
+        assertEquals(first, reader(logcatBytes("Failure")).read())
+        assertNotEquals(first?.id, reader(logcatBytes("Failure", nanos = 123_456_790)).read()?.id)
+    }
 
-            val timestampStr = raw.substring(0, secondSpace)
-            val rest = raw.substring(secondSpace + 1)
+    @Test
+    fun `one exception produces one entry containing only its top five frames`() {
+        val entries = collect(logcatBytes("Request failed\njava.io.IOException: offline\n" + frames(1..20)))
+        val entry = entries.single()
+        assertEquals("Request failed", entry.message)
+        assertTrue(entry.stackTrace.orEmpty().startsWith("java.io.IOException: offline"))
+        assertTrue(entry.stackTrace.orEmpty().contains("Mint.step5(Mint.kt:5)"))
+        assertFalse(entry.stackTrace.orEmpty().contains("Mint.step6("))
+        assertTrue(entry.stackTrace.orEmpty().endsWith("… (stack trace truncated)"))
+    }
 
-            val colonIndex = rest.indexOf(':')
-            if (colonIndex <= 0) return
+    @Test
+    fun `large stack trace split across log records updates its original entry`() {
+        val entries = collect(
+            logcatBytes("Request failed\njava.io.IOException: offline\n" + frames(1..3)) +
+                logcatBytes(frames(4..30), nanos = 124_000_000),
+        )
+        val entry = entries.single()
+        assertEquals("Request failed", entry.message)
+        assertTrue(entry.stackTrace.orEmpty().contains("Mint.step5(Mint.kt:5)"))
+        assertFalse(entry.stackTrace.orEmpty().contains("Mint.step6("))
+    }
 
-            val header = rest.substring(0, colonIndex).trim()
-            val message = rest.substring(colonIndex + 1).trim()
+    @Test
+    fun `interleaved errors from another thread do not absorb the exception tail`() {
+        val entries = collect(
+            logcatBytes("First\njava.io.IOException: offline\n" + frames(1..3)) +
+                logcatBytes("Second", tid = 99) + logcatBytes(frames(4..30)),
+        )
+        assertEquals(listOf("First", "Second"), entries.map { it.message })
+        assertNull(entries.last().stackTrace)
+    }
 
-            val parts = header.split(Regex("\\s+"))
-            val tag = parts.lastOrNull() ?: "Unknown"
+    @Test
+    fun `independent errors sharing a tag and timestamp remain separate`() {
+        val entries = collect(logcatBytes("First") + logcatBytes("Second"))
+        assertEquals(listOf("First", "Second"), entries.map { it.message })
+    }
 
-            // Parse to ensure the timestamp format is valid (even if we ignore value).
-            try {
-                logcatDateFormat.parse(timestampStr)
-            } catch (_: Exception) {
-                // ignore
-            }
+    private fun reader(bytes: ByteArray) = LogcatRecordReader(ByteArrayInputStream(bytes), 1234)
 
-            fakeStore.append(tag, message)
-        }
+    private fun collect(bytes: ByteArray): List<ErrorLogEntry> {
+        val entries = linkedMapOf<String, ErrorLogEntry>()
+        val assembler = ErrorLogAssembler { entries[it.id] = it }
+        val reader = reader(bytes)
+        while (true) assembler.accept(reader.read() ?: break)
+        return entries.values.toList()
+    }
+
+    private fun frames(range: IntRange) = range.joinToString("\n") {
+        "\tat com.example.Mint.step$it(Mint.kt:$it)"
     }
 }

--- a/app/src/test/java/com/electricdreams/numo/core/dev/ErrorLogMonitorTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/dev/ErrorLogMonitorTest.kt
@@ -1,0 +1,123 @@
+package com.electricdreams.numo.core.dev
+
+import android.app.Application
+import com.electricdreams.numo.core.data.model.ErrorLogEntry
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class ErrorLogMonitorTest {
+    @Test
+    fun `startup failure is visible and retries successfully without duplicate workers`() = runTest {
+        var attempts = 0
+        val entries = mutableListOf<ErrorLogEntry>()
+        val child = FakeProcess(ByteArrayInputStream(logcatBytes("Recovered")))
+        val monitor = ErrorLogMonitor(backgroundScope, 1234, {
+            attempts++
+            if (attempts == 1) throw IOException("Unavailable")
+            child
+        }, entries::add)
+
+        monitor.start()
+        monitor.start()
+        runCurrent()
+        assertEquals(1, attempts)
+        assertEquals(ErrorLogCollectionState.RETRYING, monitor.state.value)
+        advanceTimeBy(1_000)
+        runCurrent()
+        assertEquals(2, attempts)
+        assertEquals("Recovered", entries.single().message)
+        assertTrue(child.destroyed)
+        monitor.stop()
+        advanceTimeBy(60_000)
+        runCurrent()
+        assertEquals(2, attempts)
+        assertEquals(ErrorLogCollectionState.STOPPED, monitor.state.value)
+    }
+
+    @Test
+    fun `unexpected process exit retries with increasing bounded delay`() = runTest {
+        var attempts = 0
+        val monitor = ErrorLogMonitor(backgroundScope, 1234, {
+            attempts++
+            FakeProcess(ByteArrayInputStream(byteArrayOf()))
+        }, {})
+        monitor.start()
+        runCurrent()
+        for (delay in listOf(1_000L, 2_000L, 4_000L, 8_000L, 16_000L, 30_000L, 30_000L)) {
+            val previous = attempts
+            advanceTimeBy(delay - 1)
+            runCurrent()
+            assertEquals(previous, attempts)
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(previous + 1, attempts)
+        }
+        monitor.stop()
+    }
+
+    @Test
+    fun `stopping destroys the subprocess and unblocks a waiting read`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val readStarted = CountDownLatch(1)
+        val readReleased = CountDownLatch(1)
+        val closed = CountDownLatch(1)
+        val input = object : InputStream() {
+            override fun read(): Int {
+                readStarted.countDown()
+                closed.await(5, TimeUnit.SECONDS)
+                readReleased.countDown()
+                return -1
+            }
+
+            override fun close() { closed.countDown() }
+        }
+        val child = FakeProcess(input)
+        val monitor = ErrorLogMonitor(scope, 1234, { child }, {})
+        try {
+            monitor.start()
+            assertTrue(readStarted.await(5, TimeUnit.SECONDS))
+            assertEquals(ErrorLogCollectionState.COLLECTING, monitor.state.value)
+            monitor.stop()
+            assertTrue(child.destroyed)
+            assertTrue(readReleased.await(5, TimeUnit.SECONDS))
+            assertEquals(ErrorLogCollectionState.STOPPED, monitor.state.value)
+        } finally {
+            monitor.stop()
+            scope.cancel()
+        }
+    }
+
+    private class FakeProcess(private val input: InputStream) : Process() {
+        @Volatile var destroyed = false
+        override fun getInputStream() = input
+        override fun getErrorStream() = ByteArrayInputStream(byteArrayOf())
+        override fun getOutputStream() = ByteArrayOutputStream()
+        override fun waitFor() = 0
+        override fun exitValue() = 0
+        override fun destroy() {
+            destroyed = true
+            input.close()
+        }
+    }
+}

--- a/app/src/test/java/com/electricdreams/numo/core/dev/ErrorLogStoreTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/dev/ErrorLogStoreTest.kt
@@ -1,21 +1,26 @@
 package com.electricdreams.numo.core.dev
 
+import android.app.Application
 import android.content.Context
 import com.electricdreams.numo.AppGlobals
 import com.electricdreams.numo.core.data.model.ErrorLogEntry
+import com.google.gson.Gson
+import java.util.Date
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import java.util.Calendar
+import org.robolectric.annotation.Config
 
 /**
  * Unit tests for [ErrorLogStore].
  */
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
 class ErrorLogStoreTest {
 
     @Before
@@ -29,9 +34,8 @@ class ErrorLogStoreTest {
 
     @Test
     fun `appendError stores entries and getAllErrors returns them sorted`() {
-        ErrorLogStore.appendError(tag = "TagA", message = "First")
-        Thread.sleep(5)
-        ErrorLogStore.appendError(tag = "TagB", message = "Second")
+        ErrorLogStore.appendError(tag = "TagB", message = "Second", timestamp = Date(2_005))
+        ErrorLogStore.appendError(tag = "TagA", message = "First", timestamp = Date(2_000))
 
         val all: List<ErrorLogEntry> = ErrorLogStore.getAllErrors()
 
@@ -43,10 +47,9 @@ class ErrorLogStoreTest {
     @Test
     fun `getErrorsUpTo includes only entries at or before cutoff and keeps sort order`() {
         // First entry
-        ErrorLogStore.appendError(tag = "TagA", message = "Before")
-        Thread.sleep(5)
+        ErrorLogStore.appendError(tag = "TagA", message = "Before", timestamp = Date(2_000))
         // Second entry
-        ErrorLogStore.appendError(tag = "TagB", message = "After")
+        ErrorLogStore.appendError(tag = "TagB", message = "After", timestamp = Date(2_005))
 
         val all = ErrorLogStore.getAllErrors()
         val first = all.first().timestamp
@@ -56,6 +59,7 @@ class ErrorLogStoreTest {
         val upToFirst = ErrorLogStore.getErrorsUpTo(first)
         assertTrue(upToFirst.isNotEmpty())
         assertEquals("Before", upToFirst.first().message)
+        assertEquals(1, upToFirst.size)
 
         // Cutoff at last timestamp should include all entries, still sorted
         val upToLast = ErrorLogStore.getErrorsUpTo(last)
@@ -74,4 +78,68 @@ class ErrorLogStoreTest {
         val all = ErrorLogStore.getAllErrors()
         assertTrue(all.isEmpty())
     }
+
+    @Test
+    fun `timestamp round trip preserves milliseconds`() {
+        ErrorLogStore.appendError("Tag", "Old error", timestamp = Date(1_767_225_600_123))
+        assertEquals(1_767_225_600_123, ErrorLogStore.getAllErrors().single().timestamp.time)
+    }
+
+    @Test
+    fun `malformed history is repaired and subsequent errors can be saved`() {
+        for (json in listOf("{broken", "null", "{}", "[null, {}, {\"id\":null}]")) {
+            preferences().edit().putString("logs", json).commit()
+            assertTrue(ErrorLogStore.getAllErrors().isEmpty())
+            ErrorLogStore.appendError("Tag", "Recovered")
+            assertEquals("Recovered", ErrorLogStore.getAllErrors().single().message)
+        }
+    }
+
+    @Test
+    fun `legacy dates remain readable and malformed individual records are discarded`() {
+        val entry = ErrorLogEntry("legacy", Date(1_700_000_000_000), "Tag", "Keep me")
+        val json = "[" + Gson().toJson(entry) + ",{\"id\":\"broken\"}]"
+        preferences().edit().putString("logs", json).commit()
+        assertEquals(listOf(entry), ErrorLogStore.getAllErrors())
+        assertEquals(listOf(entry), ErrorLogStore.getAllErrors())
+    }
+
+    @Test
+    fun `replayed records and additional stack chunks do not create duplicate rows`() {
+        val entry = ErrorLogEntry("same", Date(1_000), "Tag", "Failure")
+        ErrorLogStore.record(entry)
+        ErrorLogStore.record(entry)
+        ErrorLogStore.record(entry.copy(stackTrace = "java.io.IOException: offline"))
+        assertEquals(1, ErrorLogStore.getAllErrors().size)
+        assertEquals("java.io.IOException: offline", ErrorLogStore.getAllErrors().single().stackTrace)
+    }
+
+    @Test
+    fun `direct throwable storage keeps only the exception and five frames`() {
+        val error = IllegalStateException("Failure").apply {
+            stackTrace = (1..30).map {
+                StackTraceElement("Mint", "step$it", "Mint.kt", it)
+            }.toTypedArray()
+        }
+        ErrorLogStore.appendError("Tag", "Failed", error)
+        val stack = ErrorLogStore.getAllErrors().single().stackTrace.orEmpty()
+        assertTrue(stack.contains("Mint.step5(Mint.kt:5)"))
+        assertFalse(stack.contains("Mint.step6("))
+        assertEquals(7, stack.lines().size)
+    }
+
+    @Test
+    fun `history retains the newest 500 errors when older records are replayed`() {
+        val entries = (1..500).map { ErrorLogEntry("$it", Date(it.toLong()), "Tag", "$it") }
+        for (entry in entries) ErrorLogStore.record(entry)
+        ErrorLogStore.record(ErrorLogEntry("old", Date(0), "Tag", "Old"))
+        ErrorLogStore.record(ErrorLogEntry("new", Date(501), "Tag", "New"))
+        val all = ErrorLogStore.getAllErrors()
+        assertEquals(500, all.size)
+        assertEquals("2", all.first().id)
+        assertEquals("new", all.last().id)
+    }
+
+    private fun preferences() = RuntimeEnvironment.getApplication()
+        .getSharedPreferences("DeveloperErrorLogs", Context.MODE_PRIVATE)
 }

--- a/app/src/test/java/com/electricdreams/numo/core/dev/LogcatFixture.kt
+++ b/app/src/test/java/com/electricdreams/numo/core/dev/LogcatFixture.kt
@@ -1,0 +1,32 @@
+package com.electricdreams.numo.core.dev
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** logger_entry_v4 layout from Android's log/log_read.h, followed by priority/tag/message. */
+internal fun logcatBytes(
+    message: String,
+    tag: String = "AutoWithdrawManager",
+    pid: Int = 1234,
+    tid: Int = 1235,
+    seconds: Int = 1_767_225_600,
+    nanos: Int = 123_456_789,
+    priority: Int = 6,
+    buffer: Int = 0,
+    headerSize: Int = 28,
+): ByteArray {
+    val payload = byteArrayOf(priority.toByte()) + tag.toByteArray() + byteArrayOf(0) +
+        message.toByteArray() + byteArrayOf(0)
+    return ByteBuffer.allocate(headerSize + payload.size).order(ByteOrder.LITTLE_ENDIAN).apply {
+        putShort(payload.size.toShort())
+        putShort(headerSize.toShort())
+        putInt(pid)
+        putInt(tid)
+        putInt(seconds)
+        putInt(nanos)
+        putInt(buffer)
+        if (headerSize >= 28) putInt(10_001)
+        position(headerSize)
+        put(payload)
+    }.array()
+}

--- a/app/src/test/java/com/electricdreams/numo/feature/settings/DeveloperErrorCollectionTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/settings/DeveloperErrorCollectionTest.kt
@@ -1,0 +1,52 @@
+package com.electricdreams.numo.feature.settings
+
+import android.content.Context
+import com.electricdreams.numo.NumoApplication
+import com.electricdreams.numo.core.dev.ErrorLogCollectionState
+import com.electricdreams.numo.core.dev.ErrorLogCollector
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/** Run for both debug and release to guard against accidentally gating on BuildConfig.DEBUG. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = NumoApplication::class)
+class DeveloperErrorCollectionTest {
+    @Before
+    @After
+    fun stopCollection() {
+        DeveloperPrefs.setDeveloperModeEnabled(RuntimeEnvironment.getApplication(), false)
+    }
+
+    @Test
+    fun `enabling developer mode starts collection immediately without restarting the app`() {
+        val context = RuntimeEnvironment.getApplication()
+        DeveloperPrefs.setDeveloperModeEnabled(context, true)
+        assertTrue(DeveloperPrefs.isDeveloperModeEnabled(context))
+        assertNotEquals(ErrorLogCollectionState.STOPPED, ErrorLogCollector.state.value)
+        DeveloperPrefs.setDeveloperModeEnabled(context, false)
+        assertEquals(ErrorLogCollectionState.STOPPED, ErrorLogCollector.state.value)
+    }
+
+    @Test
+    fun `application startup resumes collection for a saved developer preference`() {
+        RuntimeEnvironment.getApplication().getSharedPreferences(
+            "developer_prefs", Context.MODE_PRIVATE
+        ).edit().putBoolean("developer_mode_enabled", true).commit()
+        RuntimeEnvironment.getApplication().onCreate()
+        assertNotEquals(ErrorLogCollectionState.STOPPED, ErrorLogCollector.state.value)
+    }
+
+    @Test
+    fun `application startup leaves collection stopped when developer mode is off`() {
+        RuntimeEnvironment.getApplication().onCreate()
+        assertEquals(ErrorLogCollectionState.STOPPED, ErrorLogCollector.state.value)
+    }
+}

--- a/app/src/test/java/com/electricdreams/numo/feature/settings/ErrorLogsActivityTest.kt
+++ b/app/src/test/java/com/electricdreams/numo/feature/settings/ErrorLogsActivityTest.kt
@@ -1,0 +1,134 @@
+package com.electricdreams.numo.feature.settings
+
+import android.app.Application
+import android.app.DatePickerDialog
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Looper
+import android.view.View
+import android.widget.TextView
+import androidx.lifecycle.Lifecycle
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import com.electricdreams.numo.AppGlobals
+import com.electricdreams.numo.R
+import com.electricdreams.numo.core.dev.ErrorLogStore
+import java.util.Calendar
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowDialog
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class ErrorLogsActivityTest {
+    @Before
+    fun setUp() {
+        AppGlobals.init(RuntimeEnvironment.getApplication())
+        DeveloperPrefs.setDeveloperModeEnabled(RuntimeEnvironment.getApplication(), false)
+        ErrorLogStore.clearAll()
+    }
+
+    @Test
+    fun `new errors appear without reopening and today includes errors after screen creation`() {
+        ActivityScenario.launch(ErrorLogsActivity::class.java).use { scenario ->
+            awaitRows(scenario, 0)
+            val lateToday = Calendar.getInstance().apply {
+                set(Calendar.HOUR_OF_DAY, 23)
+                set(Calendar.MINUTE, 59)
+                set(Calendar.SECOND, 59)
+            }.time
+            ErrorLogStore.appendError("Test", "Late error", timestamp = lateToday)
+            awaitRows(scenario, 1)
+            scenario.onActivity { activity ->
+                assertEquals(View.GONE, activity.findViewById<View>(R.id.empty_view).visibility)
+                activity.findViewById<View>(R.id.copy_all_button).performClick()
+                val clipboard = activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                assertTrue(clipboard.primaryClip?.getItemAt(0)?.text.toString().contains("Late error"))
+            }
+            ErrorLogStore.clearAll()
+            awaitRows(scenario, 0)
+            scenario.onActivity { activity ->
+                assertFalse(activity.findViewById<View>(R.id.copy_all_button).isEnabled)
+                assertFalse(activity.findViewById<View>(R.id.share_button).isEnabled)
+            }
+        }
+    }
+
+    @Test
+    fun `errors arriving in the background are loaded on resume`() {
+        ActivityScenario.launch(ErrorLogsActivity::class.java).use { scenario ->
+            awaitRows(scenario, 0)
+            scenario.moveToState(Lifecycle.State.CREATED)
+            ErrorLogStore.appendError("Test", "Background error")
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            awaitRows(scenario, 1)
+        }
+    }
+
+    @Test
+    fun `selected date stays inclusive and survives recreation while history refreshes`() {
+        val yesterday = Calendar.getInstance().apply {
+            add(Calendar.DAY_OF_MONTH, -1)
+            set(Calendar.HOUR_OF_DAY, 23)
+            set(Calendar.MINUTE, 59)
+            set(Calendar.SECOND, 59)
+            set(Calendar.MILLISECOND, 999)
+        }
+        ErrorLogStore.appendError("Test", "Yesterday", timestamp = yesterday.time)
+        ErrorLogStore.appendError("Test", "Today", timestamp = Date())
+        ActivityScenario.launch(ErrorLogsActivity::class.java).use { scenario ->
+            awaitRows(scenario, 2)
+            scenario.onActivity { activity ->
+                activity.findViewById<View>(R.id.date_filter_row).performClick()
+                val dialog = ShadowDialog.getLatestDialog() as DatePickerDialog
+                dialog.datePicker.updateDate(yesterday.get(Calendar.YEAR),
+                    yesterday.get(Calendar.MONTH), yesterday.get(Calendar.DAY_OF_MONTH))
+                dialog.getButton(DatePickerDialog.BUTTON_POSITIVE).performClick()
+            }
+            awaitRows(scenario, 1)
+            scenario.recreate()
+            awaitRows(scenario, 1)
+            ErrorLogStore.appendError("Test", "More today")
+            scenario.onActivity { activity ->
+                assertEquals("Yesterday", adapter(activity).currentList.single().message)
+                assertTrue(activity.findViewById<TextView>(R.id.date_filter_value).text != "Today")
+            }
+        }
+    }
+
+    @Test
+    fun `corrupted history does not crash the screen and later errors appear`() {
+        RuntimeEnvironment.getApplication().getSharedPreferences(
+            "DeveloperErrorLogs", Context.MODE_PRIVATE
+        ).edit().putString("logs", "{broken").commit()
+        ActivityScenario.launch(ErrorLogsActivity::class.java).use { scenario ->
+            awaitRows(scenario, 0)
+            ErrorLogStore.appendError("Test", "Recovered")
+            awaitRows(scenario, 1)
+        }
+    }
+
+    private fun adapter(activity: ErrorLogsActivity) =
+        activity.findViewById<RecyclerView>(R.id.error_logs_recycler_view).adapter as ErrorLogsAdapter
+
+    private fun awaitRows(scenario: ActivityScenario<ErrorLogsActivity>, count: Int) {
+        val deadline = System.nanoTime() + 5_000_000_000L
+        var actual = -1
+        do {
+            shadowOf(Looper.getMainLooper()).idle()
+            scenario.onActivity { actual = adapter(it).itemCount }
+            if (actual == count) return
+            Thread.sleep(10)
+        } while (System.nanoTime() < deadline)
+        assertEquals(count, actual)
+    }
+}


### PR DESCRIPTION
Developer Settings could show an empty error history in release builds because collection only started in debug builds. The collector also misparsed logcat output, discarded event timestamps, and displayed exception frames as separate rows.

Enable collection when Developer Mode is turned on and restore it at application startup in every build variant. Read structured logcat records to preserve event boundaries and timestamps, combine split exceptions, and retain the exception description plus the first five stack frames for viewing, copying, and sharing. The screen now updates live, preserves the selected date across recreation, and includes the entire selected day.

Recover malformed saved history while preserving valid entries, deduplicate replayed records, and retry collector failures with visible status and bounded backoff. Add regression coverage against the production parser, store, lifecycle, and UI, plus localized collection-status messages.

Validation:

- 28 unit/Robolectric regression tests passed for both debug and release. Release unit tests were temporarily enabled with a Gradle init script; project build configuration is unchanged.
- Android 34 emulator instrumentation passed: a real `Log.e` call with a 150-frame exception appeared live as one row containing only the exception and first five frames.
- `./gradlew assembleDebug assembleRelease` succeeded.
- `./gradlew lintDebug` completed and still reports existing repository issues (210 errors and 1,328 warnings).
